### PR TITLE
Package should depends on guzzlehttp/guzzle^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.5.8",
+        "guzzlehttp/guzzle": "^6.0",
         "php": "^7.1",
 	    "ext-json": "*"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76eeef8933376091169d494e0f8fd299",
+    "content-hash": "d226d39200fc6a6296e275d7dc9bb9ce",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
This package is requiring a specific GuzzleHttp minor version or above, which can breaks compatibility with applications requiring GuzzleHttp locked between 6.0 and 6.5.7.

Changes from 6.0 to 6.5.7 and above should not cause compatibility break so we can be more permissive on this requirement.